### PR TITLE
自定义命名空间 " $loader->add( " 更正为 " $loader->addPsr4( "

### DIFF
--- a/cn-introduction/01-basic-usage.md
+++ b/cn-introduction/01-basic-usage.md
@@ -238,7 +238,7 @@ Composer 将注册一个 [PSR-4](http://www.php-fig.org/psr/psr-4/) autoloader �
 
 ```php
 $loader = require 'vendor/autoload.php';
-$loader->add('Acme\\Test\\', __DIR__);
+$loader->addPsr4('Acme\\Test\\', __DIR__);
 ```
 
 除了 PSR-4 自动加载，Composer 同时支持PSR-0、classmap 和 files自动加载。详细请查看 [自动加载-参考](04-schema.md#autoload)。


### PR DESCRIPTION
自己试验发现有误，参照了官方原版发现这里应该是 addPsr4